### PR TITLE
Adds some stuff to help to test

### DIFF
--- a/client/create_lwm2m_devices.py
+++ b/client/create_lwm2m_devices.py
@@ -1,0 +1,41 @@
+#! /bin/usr/python3
+
+from iotclient import IotClient, load_template
+import copy
+
+def get_template_attribute(template, label_value):
+	for attr in template['attrs']:
+		if attr['label'] == label_value:
+			return attr
+	return None
+
+iotc = IotClient()
+
+template_lwm2m = iotc.create_template(load_template("template_lwm2m.json"))
+template_temp_sensor = iotc.create_template(load_template("models/3303.json"))
+
+device_endpoint = "unsecure-client-endpoint"
+device_payload_base = {
+    "templates": [
+                   template_lwm2m['id'],
+                   template_temp_sensor['id']
+                 ],
+    "attrs": [
+    	{
+    		"label": "client_endpoint",
+    		"static_value": device_endpoint,
+    		"template_id": template_lwm2m['id'],
+    		"id": get_template_attribute(template_lwm2m, "client_endpoint")['id']
+    	}
+    ],
+    "label": "unsecure-dev"
+}
+
+for i in range(0, 3):
+	print("---")
+	device_payload = copy.deepcopy(device_payload_base)
+	device_payload['label'] += '-' + str(i)
+	device_payload['attrs'][0]['static_value'] += '-' + str(i)
+	device_id = iotc.create_device(device_payload)
+	print("device id: " + device_id)
+

--- a/client/create_lwm2m_devices.py
+++ b/client/create_lwm2m_devices.py
@@ -38,4 +38,3 @@ for i in range(0, 3):
 	device_payload['attrs'][0]['static_value'] += '-' + str(i)
 	device_id = iotc.create_device(device_payload)
 	print("device id: " + device_id)
-

--- a/client/create_lwm2m_with_dtls_devices.py
+++ b/client/create_lwm2m_with_dtls_devices.py
@@ -1,0 +1,45 @@
+#! /bin/usr/python3
+
+from iotclient import IotClient, load_template
+import copy
+
+def get_template_attribute(template, label_value):
+	for attr in template['attrs']:
+		if attr['label'] == label_value:
+			return attr
+	return None
+
+iotc = IotClient()
+
+template_lwm2m = iotc.create_template(load_template("template_lwm2m.json"))
+template_dtls = iotc.create_template(load_template("template_dtls.json"))
+template_temp_sensor = iotc.create_template(load_template("models/3303.json"))
+
+device_endpoint = "client-endpoint"
+device_payload_base = {
+    "templates": [
+				   template_lwm2m['id'],
+                   template_dtls['id'],
+                   template_temp_sensor['id']
+                 ],
+    "attrs": [
+    	{
+    		"label": "client_endpoint",
+    		"static_value": device_endpoint,
+    		"template_id": template_lwm2m['id'],
+    		"id": get_template_attribute(template_lwm2m, "client_endpoint")['id']
+    	}
+    ],
+    "label": "secure-dev"
+}
+
+for i in range(0, 3):
+	print("---")
+	device_payload = copy.deepcopy(device_payload_base)
+	device_payload['label'] += '-' + str(i)
+	device_payload['attrs'][0]['static_value'] += '-' + str(i)
+	device_id = iotc.create_device(device_payload)
+	print("device id: " + device_id)
+	psk = iotc.gen_psk(device_id, 16)
+	print("PSK: " + psk)
+

--- a/client/create_lwm2m_with_dtls_devices.py
+++ b/client/create_lwm2m_with_dtls_devices.py
@@ -42,4 +42,3 @@ for i in range(0, 3):
 	print("device id: " + device_id)
 	psk = iotc.gen_psk(device_id, 16)
 	print("PSK: " + psk)
-

--- a/client/iotclient.py
+++ b/client/iotclient.py
@@ -71,8 +71,7 @@ class IotClient(object):
         base_url = 'http://localhost:8000/template'
         r = requests.post(base_url, json=template, headers=self.headers)
         response = json.loads(r.text)
-        template_id = response['template']['id']
-        return template_id
+        return response['template']
 
     def create_device(self, device_payload):
         base_url = 'http://localhost:8000/device'
@@ -123,3 +122,9 @@ class IotClient(object):
         for template in response['templates']:
             url = base_url + "/" + str(template['id'])
             r = requests.delete(url, headers=self.headers)
+            
+    def gen_psk(self, device_id, key_len):
+        base_url = 'http://localhost:8000/device/gen_psk/' + device_id + '?key_length=' + str(key_len)
+        r = requests.post(base_url, headers=self.headers, params={'verbose': True})
+        return r.text
+

--- a/client/iotclient.py
+++ b/client/iotclient.py
@@ -127,4 +127,3 @@ class IotClient(object):
         base_url = 'http://localhost:8000/device/gen_psk/' + device_id + '?key_length=' + str(key_len)
         r = requests.post(base_url, headers=self.headers, params={'verbose': True})
         return r.text
-

--- a/client/models/3303.json
+++ b/client/models/3303.json
@@ -5,236 +5,92 @@
       "metadata": [
         {
           "type": "lwm2m",
-          "label": "oi",
+          "label": "path",
           "static_value": "/3303/0/5700",
-          "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
           "value_type": "string"
         }
       ],
       "type": "dynamic",
       "label": "Temperature-SensorValue-0",
-      "value_type": "float",
-      "static_value": ""
+      "value_type": "float"
     },
     {
       "metadata": [
         {
           "type": "lwm2m",
-          "label": "oi",
-          "static_value": "/3303/1/5700",
-          "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
+          "label": "path",
+          "static_value": "/3303/0/5601",
           "value_type": "string"
         }
       ],
       "type": "dynamic",
-      "label": "Temperature-SensorValue-1",
-      "value_type": "float",
-      "static_value": ""
-    },
-    {
-      "metadata": [
-        {
-          "type": "lwm2m",
-          "label": "oi",
-          "static_value": "/3303/0/5601",
-          "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
-          "value_type": "string"
-        }
-      ],
-      "type": "static",
       "label": "Temperature-MinMeasuredValue-0",
-      "value_type": "float",
-      "static_value": ""
+      "value_type": "float"
     },
     {
       "metadata": [
         {
           "type": "lwm2m",
-          "label": "oi",
-          "static_value": "/3303/1/5601",
-          "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
-          "value_type": "string"
-        }
-      ],
-      "type": "static",
-      "label": "Temperature-MinMeasuredValue-1",
-      "value_type": "float",
-      "static_value": ""
-    },
-    {
-      "metadata": [
-        {
-          "type": "lwm2m",
-          "label": "oi",
+          "label": "path",
           "static_value": "/3303/0/5602",
           "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
-          "value_type": "string"
         }
       ],
-      "type": "static",
+      "type": "dynamic",
       "label": "Temperature-MaxMeasuredValue-0",
-      "value_type": "float",
-      "static_value": ""
+      "value_type": "float"
     },
     {
       "metadata": [
         {
           "type": "lwm2m",
-          "label": "oi",
-          "static_value": "/3303/1/5602",
-          "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
-          "value_type": "string"
-        }
-      ],
-      "type": "static",
-      "label": "Temperature-MaxMeasuredValue-1",
-      "value_type": "float",
-      "static_value": ""
-    },
-    {
-      "metadata": [
-        {
-          "type": "lwm2m",
-          "label": "oi",
+          "label": "path",
           "static_value": "/3303/0/5603",
           "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
-          "value_type": "string"
         }
       ],
-      "type": "static",
+      "type": "dynamic",
       "label": "Temperature-MinRangeValue-0",
-      "value_type": "float",
-      "static_value": ""
+      "value_type": "float"
     },
     {
       "metadata": [
         {
           "type": "lwm2m",
-          "label": "oi",
-          "static_value": "/3303/1/5603",
-          "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
-          "value_type": "string"
-        }
-      ],
-      "type": "static",
-      "label": "Temperature-MinRangeValue-1",
-      "value_type": "float",
-      "static_value": ""
-    },
-    {
-      "metadata": [
-        {
-          "type": "lwm2m",
-          "label": "oi",
+          "label": "path",
           "static_value": "/3303/0/5604",
           "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
-          "value_type": "string"
         }
       ],
-      "type": "static",
+      "type": "dynamic",
       "label": "Temperature-MaxRangeValue-0",
-      "value_type": "float",
-      "static_value": ""
+      "value_type": "float"
     },
     {
       "metadata": [
         {
           "type": "lwm2m",
-          "label": "oi",
-          "static_value": "/3303/1/5604",
-          "value_type": "string"
-        },
-        {
-          "type": "meta",
-          "label": "unit",
-          "static_value": "Defined by \u201cUnits\u201d resource.",
-          "value_type": "string"
-        }
-      ],
-      "type": "static",
-      "label": "Temperature-MaxRangeValue-1",
-      "value_type": "float",
-      "static_value": ""
-    },
-    {
-      "metadata": [
-        {
-          "type": "lwm2m",
-          "label": "oi",
+          "label": "path",
           "static_value": "/3303/0/5701",
           "value_type": "string"
         }
       ],
-      "type": "static",
+      "type": "dynamic",
       "label": "Temperature-SensorUnits-0",
-      "value_type": "string",
-      "static_value": ""
+      "value_type": "string"
     },
     {
       "metadata": [
         {
           "type": "lwm2m",
-          "label": "oi",
-          "static_value": "/3303/1/5701",
-          "value_type": "string"
-        }
-      ],
-      "type": "static",
-      "label": "Temperature-SensorUnits-1",
-      "value_type": "string",
-      "static_value": ""
-    },
-    {
-      "metadata": [
-        {
-          "type": "lwm2m",
-          "label": "oi",
+          "label": "path",
           "static_value": "/3303/0/5605",
+          "value_type": "string"
+        },
+        {
+          "type": "lwm2m",
+          "label": "operations",
+          "static_value": "e",
           "value_type": "string"
         }
       ],
@@ -246,13 +102,19 @@
       "metadata": [
         {
           "type": "lwm2m",
-          "label": "oi",
-          "static_value": "/3303/1/5605",
+          "label": "path",
+          "static_value": "/3311/0/5850",
+          "value_type": "string"
+        },
+        {
+          "type": "lwm2m",
+          "label": "operations",
+          "static_value": "e",
           "value_type": "string"
         }
       ],
       "type": "actuator",
-      "label": "Temperature-ResetMinandMaxMeasuredValues-1",
+      "label": "ligth_contro_On_Off",
       "value_type": "string"
     }
   ]

--- a/client/models/3311.json
+++ b/client/models/3311.json
@@ -8,7 +8,7 @@
           "type": "lwm2m",
           "static_value": "/3311/0/5850",
           "value_type": "string",
-          "label": "oi"
+          "label": "path"
         }
       ],
       "label": "LightControl-On_Off-0"
@@ -21,32 +21,20 @@
           "type": "lwm2m",
           "static_value": "/3311/0/5851",
           "value_type": "string",
-          "label": "oi"
-        },
-        {
-          "type": "meta",
-          "static_value": "%",
-          "value_type": "string",
-          "label": "unit"
+          "label": "path"
         }
       ],
       "label": "LightControl-Dimmer-0"
     },
     {
-      "type": "dynamic",
+      "type": "actuator",
       "value_type": "integer",
       "metadata": [
         {
           "type": "lwm2m",
           "static_value": "/3311/0/5852",
           "value_type": "string",
-          "label": "oi"
-        },
-        {
-          "type": "meta",
-          "static_value": "sec",
-          "value_type": "string",
-          "label": "unit"
+          "label": "path"
         }
       ],
       "label": "LightControl-OnTime-0"
@@ -59,31 +47,23 @@
           "type": "lwm2m",
           "static_value": "/3311/0/5805",
           "value_type": "string",
-          "label": "oi"
-        },
-        {
-          "type": "meta",
-          "static_value": "Wh",
-          "value_type": "string",
-          "label": "unit"
+          "label": "path"
         }
       ],
-      "label": "LightControl-Cumulativeactivepower-0",
-      "static_value": ""
+      "label": "LightControl-Cumulativeactivepower-0"
     },
     {
-      "type": "static",
+      "type": "dynamic",
       "value_type": "float",
       "metadata": [
         {
           "type": "lwm2m",
           "static_value": "/3311/0/5820",
           "value_type": "string",
-          "label": "oi"
+          "label": "path"
         }
       ],
-      "label": "LightControl-PowerFactor-0",
-      "static_value": ""
+      "label": "LightControl-PowerFactor-0"
     },
     {
       "type": "actuator",
@@ -93,24 +73,23 @@
           "type": "lwm2m",
           "static_value": "/3311/0/5706",
           "value_type": "string",
-          "label": "oi"
+          "label": "path"
         }
       ],
       "label": "LightControl-Colour-0"
     },
     {
-      "type": "static",
+      "type": "dynamic",
       "value_type": "string",
       "metadata": [
         {
           "type": "lwm2m",
           "static_value": "/3311/0/5701",
           "value_type": "string",
-          "label": "oi"
+          "label": "path"
         }
       ],
-      "label": "LightControl-SensorUnits-0",
-      "static_value": ""
+      "label": "LightControl-SensorUnits-0"
     }
   ],
   "label": "Light Control"

--- a/client/template_dtls.json
+++ b/client/template_dtls.json
@@ -1,0 +1,32 @@
+{
+  "label": "Template_dtls",
+  "attrs": [
+    {
+      "label": "pre_shared_key",
+      "type": "static",
+      "value_type": "psk",
+      "metadata": [
+        {
+          "type": "lwm2m",
+          "value_type": "string",
+          "static_value": "/0/0/5",
+          "label": "path"
+        }
+      ]
+    },
+    {
+      "label": "pre_shared_key_identity",
+      "type": "static",
+      "value_type": "string",
+      "static_value": "key_id",
+      "metadata": [
+        {
+          "type": "lwm2m",
+          "value_type": "string",
+          "static_value": "/0/0/3",
+          "label": "path"
+        }
+      ]      
+    }
+  ]
+}

--- a/client/template_lwm2m.json
+++ b/client/template_lwm2m.json
@@ -1,0 +1,11 @@
+{
+  "label": "Template_lwm2m",
+  "attrs": [
+    {
+      "label": "client_endpoint",
+      "type": "static",
+      "value_type": "string",
+      "static_value": "client_endpoint_default"
+    }
+  ]
+}


### PR DESCRIPTION
- Adds some python examples that shows how to create devices using
LWM2M with and without DTLS;
- Adapts the 3303 and 3311 templates to work with the new iotagent version;
- Adds base templates that illustrates the basics parameters to configure
a LWM2M device;
- Adapts the python script that converts the OMA models to Dojot models to
work with the new iotagent version.