### PR TITLE
Changed to not run iotagent process as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM zenika/alpine-maven:3-jdk8
 
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
 RUN mkdir -p /usr/src/app/data
 
 ADD pom.xml /usr/src/app/pom.xml


### PR DESCRIPTION
The way the docker container is built runs the IoT-Agent Leshan with PID 1. This is not adequate once this PID is reserved for a supervising process. Furthermore, the signaling handling works a little different for it. The solution was to change the dockerfile to run tini with PID 1.

Linked with dojot/dojot#1037