### PR TITLE
Bugfix/1046 zombie process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM zenika/alpine-maven:3-jdk8
 
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
+
 RUN mkdir -p /usr/src/app/data
 
 ADD pom.xml /usr/src/app/pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
                 </executions>
             </plugin>
 
-            <plugin>    
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
@@ -131,12 +131,12 @@
         <dependency>
             <groupId>com.github.dojot</groupId>
             <artifactId>iotagent-java</artifactId>
-            <version>a22242e1775bc62fc0acee215b75c96fa4d6ae0a</version>
+            <version>da6f509334a4d34af66adab41feb27c082445c1f</version>
         </dependency>
         <dependency>
             <groupId>com.github.dojot</groupId>
             <artifactId>dojot-module-java</artifactId>
-            <version>f1ead0443f81f8c9304a45bfbec39bb55fc60f74</version>
+            <version>6e9cebd903a00e65ac7a9fac00333d769e2fb7a9</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.californium</groupId>

--- a/src/main/java/org/cpqd/iotagent/LwM2MAgent.java
+++ b/src/main/java/org/cpqd/iotagent/LwM2MAgent.java
@@ -48,11 +48,15 @@ public class LwM2MAgent implements Runnable {
 
 
     public LwM2MAgent(long consumerPollTime, ImageDownloader imageDownloader, FileServerPskStore pskStore) {
-        this.eventHandler = new IoTAgent(consumerPollTime);
+        try {
+            this.eventHandler = new IoTAgent(consumerPollTime);
+        }
+        catch (Exception ex) {
+            logger.error("IoT-Agent initialization failed. Bailing out! (" + ex + ")");
+            System.exit(1);
+        }
         this.deviceMapper = new DeviceMapper();
-
         this.securityStore = new InMemorySecurityStore();
-
         this.imageDownloader = imageDownloader;
         this.fsPskStore = pskStore;
 
@@ -80,8 +84,8 @@ public class LwM2MAgent implements Runnable {
      * This method is part of Firmware Update. The first thing to do in a firmware update in LwM2m protocol
      * is send the Package URI to the device. The next step, is wait until the device send that his state
      * has changed to downloaded (state 2), and, then, actuate on the attribute "FWUpdate-Update", that
-     * will trigger the Firmware Update on the device. 
-     * @param registration, newFwVersion, tenant 
+     * will trigger the Firmware Update on the device.
+     * @param registration, newFwVersion, tenant
      * @return
      */
     private Integer sendsUriToDevice(Registration registration, String imageLabel,
@@ -246,7 +250,7 @@ public class LwM2MAgent implements Runnable {
             } catch (NonUniqueSecurityInfoException e) {
                 e.printStackTrace();
                 return null;
-            }			
+            }
          } else {
              logger.debug("device: " + deviceId + " is not using DTLS");
          }
@@ -310,7 +314,7 @@ public class LwM2MAgent implements Runnable {
         } catch (Exception e) {
             // this it not a lwm2m device, just skip it
             return null;
-        }        
+        }
 
         if (device.isSecure()){
             DeviceAttribute pskIdentityAttr = device.getAttributeByPath("/0/0/3");
@@ -367,7 +371,7 @@ public class LwM2MAgent implements Runnable {
                     String imageLabel = devAttr.getTemplateId();
                     logger.info("Image id that came on actuation: " + imageVersion);
                     this.sendsUriToDevice(controlStruture.registration, imageLabel, imageVersion, tenant, device.isSecure());
-                    return null; 
+                    return null;
                 }
 
                 if (devAttr.isExecutable()) {


### PR DESCRIPTION
When the initialization of the agent fails, one of the threads dies, but the others keep running. The expected behavior is that the process dies too. The fix consists in catch the exception threw in this case and force the process terminates.