### PR TITLE
Adds support to firmware update via HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Using this agent you can:
 - monitor LwM2M resources
 - interact with LwM2M resources (write and execute)
 - use DTLS communication (only with PSK)
-- firmware update
+- firmware update (Only the protocols COAP, COAPS and HTTP are supported. 
+Actually HTTPS is not supported. The delivery method PUSH is not supported)
+- deal with multidimensional resources (just reading, writing is not supported yet)
 Please note that:
 - LwM2M attributes are not supported
-- multidimensional resources are not supported
 
 # How to create a dojot's device in compliance to this agent
 
@@ -54,6 +55,10 @@ The following metadata should be included if your attribute has execution proper
   ]
 ```
 
+Please, note that the support to multidimentional resources is initial, for now
+is only possible to read this kind of resource. All multidimentional resources are
+exported as string with the following format: `LwM2mMultipleResource [values=%s, type=%s]`.
+
 # How to encapsulates the service into a Docker container
 
 In order to use this service in the dojot environment we need to encapsulate it
@@ -65,12 +70,23 @@ docker build -t dojot/iotagent-lwm2m .
 Obs: just note that `dojot/iotagent-lwm2m` is the image name, you can replace it
 with some other name that you desire.
 
+# Firmware update
+
+In order to the firmware process execute make sure your device implements the
+LwM2M objects 3 (device) and 5 (firmware update).
+You can find a firmware update template sample [here](client/firmware_update.json).
+
+Attention: the delivery method PUSH is not supported yet.
+
 # Environment variables
 
 This service relies on some environment variables to configure some aspects.
 These variables are the following ones:
   - DOJOT_MANAGEMENT_USER:
-  - KAFKA_GROUP_ID:     
-  - FILE_SERVER_ADDRESS:
+  - KAFKA_GROUP_ID: kafka's consumer group id
+  - FILE_SERVER_ADDRESS: address that the file server will be listening (127.0.0.1)
+  - FILE_SERVER_DATA_PATH: path where the firmware images will be stored (./data)
+  - FILE_SERVER_HTTP_PORT: port that the file server will be listening for HTTP protocol (5896)
+  - FILE_SERVER_HTTPS_PORT: port that the file server will be listening for HTTPS protocol (5897) *NOT SUPPORTED*
 
-   
+Please, note that there are also some configurations that are read from the file `fileServerCoAP.properties`.

--- a/client/create_lwm2m_devices.py
+++ b/client/create_lwm2m_devices.py
@@ -13,7 +13,7 @@ iotc = IotClient()
 
 template_lwm2m = iotc.create_template(load_template("template_lwm2m.json"))
 template_temp_sensor = iotc.create_template(load_template("models/3303.json"))
-template_fw_update = iotc.create_template(load_template("firmware_update.json"))
+template_fw_update = iotc.create_template(load_template("template_firmware_update.json"))
 
 device_endpoint = "unsecure-client-endpoint"
 device_payload_base = {
@@ -33,7 +33,7 @@ device_payload_base = {
     "label": "unsecure-dev"
 }
 
-for i in range(0, 3):
+for i in range(0, 1):
 	print("---")
 	device_payload = copy.deepcopy(device_payload_base)
 	device_payload['label'] += '-' + str(i)

--- a/client/create_lwm2m_with_dtls_devices.py
+++ b/client/create_lwm2m_with_dtls_devices.py
@@ -14,7 +14,7 @@ iotc = IotClient()
 template_lwm2m = iotc.create_template(load_template("template_lwm2m.json"))
 template_dtls = iotc.create_template(load_template("template_dtls.json"))
 template_temp_sensor = iotc.create_template(load_template("models/3303.json"))
-template_fw_update = iotc.create_template(load_template("firmware_update.json"))
+template_fw_update = iotc.create_template(load_template("template_firmware_update.json"))
 
 device_endpoint = "client-endpoint"
 device_payload_base = {

--- a/client/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/FirmwareUpdateObject.java
+++ b/client/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/FirmwareUpdateObject.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.Vector;
 
 import org.eclipse.leshan.client.resource.BaseInstanceEnabler;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -35,23 +36,69 @@ public class FirmwareUpdateObject extends BaseInstanceEnabler {
     static final int UR_FAIL_DOWNLOAD = 4;
     static final int UR_INTEGRITY_CHECK_FAILED = 5;
 
+    static final long PROTOCOL_COAP = 0;
+    static final long PROTOCOL_COAPS = 1;
+    static final long PROTOCOL_HTTP = 2;
+    static final long PROTOCOL_HTTPS = 3;
+
+    static final int DELIVERY_METHOD_BOTH = 2;
+
+    private Map<Integer, Long> protocols;
+    private int deliveryMethod;
+
     private static final Logger LOG = LoggerFactory.getLogger(FirmwareUpdateObject.class);
 
-    private static final List<Integer> supportedResources = Arrays.asList(1, 2, 3, 5);
-    public FirmwareUpdateObject() {
+    private static final List<Integer> supportedResources = Arrays.asList(1, 2, 3, 5, 8, 9);
+    public FirmwareUpdateObject(String[] protocols) {
         URI = "";
+        this.deliveryMethod = DELIVERY_METHOD_BOTH;
+
+        this.protocols = new HashMap<Integer, Long>();
+        int protocolCount = 0;
+        for (int i =0; i < protocols.length; ++i) {
+            if (protocols[i].equalsIgnoreCase("coap")) {
+                this.protocols.put(protocolCount, PROTOCOL_COAP);
+                ++protocolCount;
+                LOG.info("This device suppots the firmware update protocol: COAP");
+            } else if (protocols[i].equalsIgnoreCase("coaps")) {
+                this.protocols.put(protocolCount, PROTOCOL_COAPS);
+                ++protocolCount;
+                LOG.info("This device suppots the  firmware update protocol: COAPS");
+            } else if (protocols[i].equalsIgnoreCase("http")) {
+                this.protocols.put(protocolCount, PROTOCOL_HTTP);
+                ++protocolCount;
+                LOG.info("This device suppots the  firmware update protocol: HTTP");
+            } else if (protocols[i].equalsIgnoreCase("https")) {
+                this.protocols.put(protocolCount, PROTOCOL_HTTPS);
+                ++protocolCount;
+                LOG.info("This device suppots the  firmware update protocol: HTTPS");
+            }
+        }
+
+        if (protocolCount == 0) {
+            this.protocols.put(protocolCount, PROTOCOL_COAP);
+        }
     }
 
     @Override
     public ReadResponse read(int resourceid) {
-        LOG.info("Read on Device Resource " + resourceid);
+        LOG.info("Read on Device Resource /5/0/" + resourceid);
         switch (resourceid) {
         case 1:
+            LOG.info("Device Resource /5/0/" + resourceid + " value: " + getURI());
             return ReadResponse.success(resourceid, getURI());
         case 3:
+            LOG.info("Device Resource /5/0/" + resourceid + " value: " + getState());
             return ReadResponse.success(resourceid, getState());
         case 5:
+            LOG.info("Device Resource /5/0/" + resourceid + " value: " + getUpdateResult());
             return ReadResponse.success(resourceid, getUpdateResult());
+        case 8:
+            LOG.info("Device Resource /5/0/" + resourceid + " value: " + getProtocols().toString());
+            return ReadResponse.success(resourceid, getProtocols(), Type.INTEGER);
+        case 9:
+            LOG.info("Device Resource /5/0/" + resourceid + " value: " + getDeliveryMethod());
+            return ReadResponse.success(resourceid, getDeliveryMethod());
         default:
             return super.read(resourceid);
         }
@@ -60,12 +107,14 @@ public class FirmwareUpdateObject extends BaseInstanceEnabler {
     @Override
     public ExecuteResponse execute(int resourceid, String params) {
         LOG.info("Execute on Firmware Update resource " + resourceid);
-        if (params != null && params.length() != 0)
+        if (params != null && params.length() != 0) {
             System.out.println("\t params " + params);
-        switch(resourceid){
+        }
+        switch (resourceid) {
             case 2:
                 setState(STATE_UPDATING);
                 fireResourcesChange(RESOURCE_STATE);
+                LOG.info("Updating firmware...");
                 Runnable r1 = new Runnable() {
 
                     public void run (){
@@ -75,6 +124,7 @@ public class FirmwareUpdateObject extends BaseInstanceEnabler {
                             fireResourcesChange(RESOURCE_STATE);
                             setUpdateResult(UR_SUCCESS);
                             fireResourcesChange(RESOURCE_UPDATE_RESULT);
+                            LOG.info("...firmware update successfully");
                         } catch (Exception error) {
                             System.out.println(error);
                         }
@@ -89,7 +139,7 @@ public class FirmwareUpdateObject extends BaseInstanceEnabler {
 
     @Override
     public WriteResponse write(int resourceid, LwM2mResource value) {
-        LOG.info("Write on Device Resource " + resourceid + " value " + value);
+        LOG.info("Write on Device Resource /5/0/" + resourceid + " value " + value);
         switch (resourceid) {
         case 1:
         try {
@@ -98,6 +148,7 @@ public class FirmwareUpdateObject extends BaseInstanceEnabler {
             fireResourcesChange(resourceid);
             setState(STATE_DOWNLOADING);
             fireResourcesChange(RESOURCE_STATE);
+            LOG.info("Downloading firmware image... [dummy]");
             Runnable r1 = new Runnable() {
 
                 public void run (){
@@ -106,14 +157,15 @@ public class FirmwareUpdateObject extends BaseInstanceEnabler {
                         if(checkURI(getURI())){
                             setState(STATE_DOWNLOADED);
                             fireResourcesChange(RESOURCE_STATE);
+                            LOG.info("...firmware image download successfully");
                         } else {
                             setState(STATE_IDLE);
                             fireResourcesChange(RESOURCE_STATE);
-
-                            if(getURI()==null || getURI().isEmpty()){
+                            LOG.info("...firmware image download failed");
+                            if (getURI()==null || getURI().isEmpty()) {
                                 setUpdateResult(UR_INTEGRITY_CHECK_FAILED);
-                                fireResourcesChange(RESOURCE_UPDATE_RESULT);
-                            }else{
+                                fireResourcesChange(RESOURCE_UPDATE_RESULT);                                
+                            } else{
                                 setUpdateResult(UR_FAIL_DOWNLOAD);
                                 fireResourcesChange(RESOURCE_UPDATE_RESULT);
                             }
@@ -175,6 +227,14 @@ public class FirmwareUpdateObject extends BaseInstanceEnabler {
 
     private int getState(){
         return state;
+    }
+
+    private Map<Integer, Long> getProtocols() {
+        return this.protocols;
+    }
+
+    private int getDeliveryMethod() {
+        return this.deliveryMethod;
     }
 
     private void setState(int s){

--- a/client/template_dtls.json
+++ b/client/template_dtls.json
@@ -1,5 +1,5 @@
 {
-  "label": "Template_dtls",
+  "label": "dtls",
   "attrs": [
     {
       "label": "pre_shared_key",

--- a/client/template_firmware_update.json
+++ b/client/template_firmware_update.json
@@ -1,8 +1,8 @@
 {
-  "label": "Firmware Update",
+  "label": "firmware_update",
   "attrs": [
     {
-      "label": "FWUpdate-PackageURI",
+      "label": "fwu_package_uri",
       "type": "actuator",
       "value_type": "string",
       "metadata": [
@@ -21,7 +21,7 @@
       ]
     },
     {
-      "label": "FWUpdate-State",
+      "label": "fwu_state",
       "type": "dynamic",
       "value_type": "integer",
       "metadata": [
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "label": "FWUpdate-UpdateResult",
+      "label": "fwu_update_result",
       "type": "dynamic",
       "value_type": "integer",
       "metadata": [
@@ -59,7 +59,7 @@
       ]
     },
     {
-      "label": "FWUpdate-Update",
+      "label": "fwu_update",
       "type": "actuator",
       "value_type": "string",
       "metadata": [
@@ -84,7 +84,7 @@
       ]
     },
     {
-      "label": "Firmware-version",
+      "label": "firmware_version",
       "type": "dynamic",
       "value_type": "string",
       "metadata": [
@@ -98,6 +98,19 @@
           "type": "lwm2m",
           "label": "path",
           "static_value": "/3/0/3",
+          "value_type": "string"
+        }
+      ]
+    },
+    {
+      "label": "fwu_protocol",
+      "type": "dynamic",
+      "value_type": "integer",
+      "metadata": [
+        {
+          "type": "lwm2m",
+          "label": "path",
+          "static_value": "/5/0/8",
           "value_type": "string"
         }
       ]

--- a/client/template_lwm2m.json
+++ b/client/template_lwm2m.json
@@ -1,5 +1,5 @@
 {
-  "label": "Template_lwm2m",
+  "label": "lwm2m",
   "attrs": [
     {
       "label": "client_endpoint",

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,11 @@
             <artifactId>californium-core</artifactId>
             <version>2.0.0-M6</version>
         </dependency>
+        <dependency>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>jetty</artifactId>
+            <version>6.1.26</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -144,9 +144,9 @@
             <version>2.0.0-M6</version>
         </dependency>
         <dependency>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>jetty</artifactId>
-            <version>6.1.26</version>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>9.4.20.v20190813</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/cpqd/iotagent/Config.java
+++ b/src/main/java/org/cpqd/iotagent/Config.java
@@ -1,0 +1,62 @@
+package org.cpqd.iotagent;
+
+public class Config {
+
+    private static Config mInstance;
+
+    private String mFileServerAddress;
+    private String mFileServerDataPath;
+    private int mFileServerHttpPort;
+    private int mFileServerHttpsPort;
+
+    private Config() {
+
+        if (System.getenv("FILE_SERVER_ADDRESS") == null) {
+            this.mFileServerAddress = "127.0.0.1";
+        } else {
+            this.mFileServerAddress = System.getenv("FILE_SERVER_ADDRESS");
+        }
+
+        if (System.getenv("FILE_SERVER_DATA_PATH") == null) {
+            this.mFileServerDataPath = "./data";
+        } else {
+            this.mFileServerDataPath = System.getenv("FILE_SERVER_DATA_PATH");
+        }
+
+        if (System.getenv("FILE_SERVER_HTTP_PORT") == null) {
+            this.mFileServerHttpPort = 5896;
+        } else {
+            this.mFileServerHttpPort = Integer.parseInt(System.getenv("FILE_SERVER_HTTP_PORT"));
+        }
+
+        if (System.getenv("FILE_SERVER_HTTPS_PORT") == null) {
+            this.mFileServerHttpsPort = 5897;
+        } else {
+            this.mFileServerHttpsPort = Integer.parseInt(System.getenv("FILE_SERVER_HTTPS_PORT"));
+        }
+
+    }
+
+    public static synchronized Config getInstance() {
+        if (mInstance == null) {
+            mInstance = new Config();
+        }
+        return mInstance;
+    }
+
+    public String getFileServerAddress() {
+        return this.mFileServerAddress;
+    }
+
+    public String getFileServerDataPath() {
+        return this.mFileServerDataPath;
+    }
+
+    public int getFileServerHttpPort() {
+        return this.mFileServerHttpPort;
+    }
+
+    public int getFileServerHttpsPort() {
+        return this.mFileServerHttpsPort;
+    }
+}

--- a/src/main/java/org/cpqd/iotagent/Device.java
+++ b/src/main/java/org/cpqd/iotagent/Device.java
@@ -53,7 +53,6 @@ public class Device {
 
     public Boolean isSecure() {
         DeviceAttribute pskAttr = this.getAttributeByPath(SecurityPath.PRE_SHARED_SECRET_KEY);
-        logger.info(pskAttr);
         if (pskAttr != null) {
             if (!pskAttr.getValueType().equals("psk")) {
                 logger.error("device " + this.deviceId + ": invalid psk value type, it must be 'psk'");

--- a/src/main/java/org/cpqd/iotagent/DeviceAttribute.java
+++ b/src/main/java/org/cpqd/iotagent/DeviceAttribute.java
@@ -65,31 +65,25 @@ public class DeviceAttribute {
     }
 
     private void addPathOpMeta(String label) {
-        logger.debug("This is the label: " + label);
         switch (label) {
             case "dojot:firmware_update:state":
-                logger.debug("state, adding path and setting islwm2mattr to true");
                 this.path = FirmwareUpdatePath.STATE;
                 this.isLwM2MAttr = true;
                 break;
             case "dojot:firmware_update:update_result":
-                logger.debug("result, adding path and setting islwm2mattr to true");
                 this.path = FirmwareUpdatePath.UPDATE_RESULT;
                 this.isLwM2MAttr = true;
                 break;
             case "dojot:firmware_update:update":
-                logger.debug("update, adding path and setting islwm2mattr to true");
                 this.path = FirmwareUpdatePath.UPDATE;
                 this.isLwM2MAttr = true;
                 this.operations = ResourceModel.Operations.E;
                 break;
             case "dojot:firmware_update:desired_version":
-                logger.debug("update, adding path and setting islwm2mattr to true");
                 this.path = FirmwareUpdatePath.PACKAGE_URI;
                 this.isLwM2MAttr = true;
                 break;
             case "dojot:firmware_update:version":
-                logger.debug("update, adding path and setting islwm2mattr to true");
                 this.path = DevicePath.FIRMWARE_VERSION;
                 this.isLwM2MAttr = true;
                 break;

--- a/src/main/java/org/cpqd/iotagent/LwM2MAgent.java
+++ b/src/main/java/org/cpqd/iotagent/LwM2MAgent.java
@@ -172,6 +172,8 @@ public class LwM2MAgent implements Runnable {
                 case FirmwareUpdatePath.PROTOCOL_HTTPS:
                     isHttpsSupported = true;
                     break;
+                default:
+                    break;
             }
         }
 

--- a/src/main/java/org/cpqd/iotagent/LwM2mHandler.java
+++ b/src/main/java/org/cpqd/iotagent/LwM2mHandler.java
@@ -13,11 +13,13 @@ import org.eclipse.leshan.core.request.ObserveRequest;
 import org.apache.log4j.Logger;
 import org.eclipse.leshan.core.request.WriteRequest;
 import org.eclipse.leshan.core.request.ReadRequest;
+import org.eclipse.leshan.core.node.LwM2mMultipleResource;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
+import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.server.LwM2mServer;
 import org.eclipse.leshan.server.registration.Registration;
 
@@ -34,8 +36,8 @@ public class LwM2mHandler {
         this.server = server;
     }
 
-    public LwM2mSingleResource ObserveResource(Registration registration, String path) {
-        LwM2mSingleResource resource = null;
+    public LwM2mResource ObserveResource(Registration registration, String path) {
+        LwM2mResource resource = null;
         try {
             Integer pathArray[] = DeviceAttribute.getIdsfromPath(path);
             ObserveResponse response = server.send(registration,
@@ -50,11 +52,11 @@ public class LwM2mHandler {
                 return null;
             }
             LwM2mNode lwm2mNode = response.getContent();
-            if (!(lwm2mNode instanceof LwM2mSingleResource)) {
+            if (!(lwm2mNode instanceof LwM2mResource)) {
                 this.mLogger.warn("Unsuported content object.");
                 return null;
             }
-            resource = (LwM2mSingleResource)lwm2mNode;
+            resource = (LwM2mResource)lwm2mNode;
         } catch (Exception e) {
             // Todo(jsiloto): Log errors here
             e.printStackTrace();
@@ -103,6 +105,34 @@ public class LwM2mHandler {
         		return null;
         	}
         	resource = (LwM2mSingleResource)lwm2mNode;
+        } catch (Exception e) {
+            e.printStackTrace();
+            this.mLogger.error(e);
+        }
+        return resource;
+    }
+
+    public LwM2mMultipleResource ReadMultipleResource(Registration registration, String path) {
+        LwM2mMultipleResource resource = null;
+        try {
+            Integer pathArray[] = DeviceAttribute.getIdsfromPath(path);
+            ReadResponse response = server.send(registration,
+                new ReadRequest(pathArray[0], pathArray[1], pathArray[2]), readTimout);
+            if (response == null) {
+                this.mLogger.error("read request timed out");
+                return null;
+            }
+            if (!response.isSuccess()) {
+                this.mLogger.error("read request failed. Error: " +
+                    response.toString());
+                return null;
+            }                
+            LwM2mNode lwm2mNode = response.getContent();
+            if (!(lwm2mNode instanceof LwM2mMultipleResource)) {
+        		this.mLogger.warn("Unsuported content object.");
+        		return null;
+        	}
+        	resource = (LwM2mMultipleResource)lwm2mNode;
         } catch (Exception e) {
             e.printStackTrace();
             this.mLogger.error(e);

--- a/src/main/java/org/cpqd/iotagent/SimpleFileServerCoap.java
+++ b/src/main/java/org/cpqd/iotagent/SimpleFileServerCoap.java
@@ -43,10 +43,10 @@ import org.eclipse.californium.scandium.dtls.pskstore.PskStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SimpleFileServer extends CoapServer {
-	private static final Logger LOG = LoggerFactory.getLogger(SimpleFileServer.class.getName());
+public class SimpleFileServerCoap extends CoapServer {
+	private static final Logger LOG = LoggerFactory.getLogger(SimpleFileServerCoap.class.getName());
 
-	public SimpleFileServer(File coapConfigFile, PskStore pskStore) {
+	public SimpleFileServerCoap(File coapConfigFile, PskStore pskStore) {
 		NetworkConfig netConfig = NetworkConfig.createStandardWithFile(coapConfigFile);
 		
 		int coapPort = netConfig.getInt(NetworkConfig.Keys.COAP_PORT);

--- a/src/main/java/org/cpqd/iotagent/SimpleFileServerHttp.java
+++ b/src/main/java/org/cpqd/iotagent/SimpleFileServerHttp.java
@@ -1,15 +1,16 @@
 /**
  * A simple HTTP file server.
- * Implementation based on MG4J implementation:
- * https://raw.githubusercontent.com/bantudb/mg4j/master/src/it/unimi/di/big/mg4j/query/HttpFileServer.java
- * accessed on 25 jun 2019
+ * Implementation based on jetty documentation:
+ * https://www.eclipse.org/jetty/documentation/current/embedded-examples.html#embedded-file-server
+ * accessed on 20 ago 2019
  */
 package org.cpqd.iotagent;
 
-import org.mortbay.jetty.Server;
-import org.mortbay.jetty.handler.ResourceHandler;
-import org.mortbay.jetty.handler.ContextHandler;
-import org.mortbay.jetty.bio.SocketConnector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.HandlerList;
+import org.eclipse.jetty.server.handler.ResourceHandler;
 
 
 public class SimpleFileServerHttp extends Thread {
@@ -30,26 +31,21 @@ public class SimpleFileServerHttp extends Thread {
     public void run() {
         try {
             // Create the server
-            this.mServer = new Server();
+            this.mServer = new Server(this.mServerPort);
 
-            // Create a port listener
-            SocketConnector connector = new SocketConnector();
-            connector.setPort(this.mServerPort);
-            this.mServer.addConnector(connector);
-
-            // Create a context
-            ContextHandler context = new ContextHandler();
-            context.setContextPath("/");
-            context.setResourceBase(this.mDataPath);
-
-            // Add a resource handler
             ResourceHandler resourceHandler = new ResourceHandler();
-            context.addHandler(resourceHandler);
-            
-            this.mServer.addHandler(context);
+
+            resourceHandler.setDirectoriesListed(true);
+
+            resourceHandler.setResourceBase(this.mDataPath);
+
+            HandlerList handlers = new HandlerList();
+            handlers.setHandlers(new Handler[]{resourceHandler, new DefaultHandler()});
+            this.mServer.setHandler(handlers);
 
             // Start the http server
-            mServer.start();
+            this.mServer.start();
+            this.mServer.join();
         } catch ( Exception e ) {
             throw new RuntimeException();
         }

--- a/src/main/java/org/cpqd/iotagent/SimpleFileServerHttp.java
+++ b/src/main/java/org/cpqd/iotagent/SimpleFileServerHttp.java
@@ -1,0 +1,57 @@
+/**
+ * A simple HTTP file server.
+ * Implementation based on MG4J implementation:
+ * https://raw.githubusercontent.com/bantudb/mg4j/master/src/it/unimi/di/big/mg4j/query/HttpFileServer.java
+ * accessed on 25 jun 2019
+ */
+package org.cpqd.iotagent;
+
+import org.mortbay.jetty.Server;
+import org.mortbay.jetty.handler.ResourceHandler;
+import org.mortbay.jetty.handler.ContextHandler;
+import org.mortbay.jetty.bio.SocketConnector;
+
+
+public class SimpleFileServerHttp extends Thread {
+    /** The server itself. */
+    private Server mServer;
+    /** The server's port. */
+    private int mServerPort;
+    /** The server's port. */
+    private String mDataPath;
+    
+    public SimpleFileServerHttp(int port, String path) {
+        this.mServerPort = port;
+        this.mDataPath = path;
+        this.mServer = null;
+    }
+
+    @Override
+    public void run() {
+        try {
+            // Create the server
+            this.mServer = new Server();
+
+            // Create a port listener
+            SocketConnector connector = new SocketConnector();
+            connector.setPort(this.mServerPort);
+            this.mServer.addConnector(connector);
+
+            // Create a context
+            ContextHandler context = new ContextHandler();
+            context.setContextPath("/");
+            context.setResourceBase(this.mDataPath);
+
+            // Add a resource handler
+            ResourceHandler resourceHandler = new ResourceHandler();
+            context.addHandler(resourceHandler);
+            
+            this.mServer.addHandler(context);
+
+            // Start the http server
+            mServer.start();
+        } catch ( Exception e ) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/src/main/java/org/cpqd/iotagent/lwm2m/objects/FirmwareUpdatePath.java
+++ b/src/main/java/org/cpqd/iotagent/lwm2m/objects/FirmwareUpdatePath.java
@@ -36,4 +36,33 @@ public class FirmwareUpdatePath {
      */
     public static final String UPDATE_RESULT = "/5/0/5";
 
+    /**
+     * This resource indicates what protocols the LwM2M Client implements to
+     * retrieve firmware images.
+     */
+    public static final String FIRMWARE_UPDATE_PROTOCOL_SUPPORT = "/5/0/8";
+
+    /**
+     * The LwM2M Client uses this resource to indicate its support for transferring firmware
+     * images to the client either via the Package Resource (=push) or via the Package URI
+     * Resource (=pull) mechanism.
+     */
+    public static final String FIRMWARE_UPDATE_DELIVERY_METHOD = "/5/0/9";
+
+    /**
+     * Values that represents the supported protocol to execute the firmware
+     * update process
+     */
+    public static final int PROTOCOL_COAP = 0;
+    public static final int PROTOCOL_COAPS = 1;
+    public static final int PROTOCOL_HTTP = 2;
+    public static final int PROTOCOL_HTTPS = 3;
+
+    /**
+     * Values that represents the supported delivery method to transfer the firmware
+     * image
+     */
+    public static final int DELIVERY_METHOD_PULL = 0;
+    public static final int DELIVERY_METHOD_PUSH = 1;
+    public static final int DELIVERY_METHOD_BOTH = 2;
 }


### PR DESCRIPTION
- Adds the use of the LwM2M object resource '5/0/8' to consult
the protocol supported by the device, it decides the URI format
that will be sent to the device.
- Adds the use of the LwM2M object resource '/5/0/9' to consult
the firmware update's delivery method supported (PUSH method is not supported yet)
- Adds the possibility to configure the firmware storage directory via
environment variable (FIRMWARE_UPDATE_DATA_PATH)
- Adds a file server HTTP. the port can be configured via environment
variable (FIRMWARE_UPDATE_HTTP_PORT)
- Updates the README
- Updates the client demo to export the lwm2m object resource '5/0/8'
- Adds a new configuration to the client demo (-protocols) which gives
the possibility to the user configure the protocols supported by the
device
- Improves client demo log
- Adds a initial support to read LwM2M resources multidimentional

ATTENTION: HTTPS is not supported as protocol to transfer the firmware image.